### PR TITLE
Update outputs for versions greater than 3.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ module "irsa" {
 | eks\_cluster | EKS cluster name (workspace) where the role is going to be linked | `string` | `"live"` | no |
 | namespace | namespace where the service account to be linked is located | `string` | n/a | yes |
 | role\_policy\_arns | List of ARNs of IAM policies to attach to IAM role | `list(string)` | n/a | yes |
+| service\_account | service accounts | `string` | n/a | yes |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -25,7 +25,7 @@ resource "kubernetes_service_account" "generated_sa" {
     name      = local.identifier
     namespace = var.namespace
     annotations = {
-      "eks.amazonaws.com/role-arn" = module.iam_assumable_role.this_iam_role_arn
+      "eks.amazonaws.com/role-arn" = module.iam_assumable_role.iam_role_arn
     }
   }
   automount_service_account_token = true

--- a/outputs.tf
+++ b/outputs.tf
@@ -5,5 +5,5 @@ output "aws_iam_role_name" {
 
 output "service_account_name" {
   description = "Name of the service account created"
-  value       = kubernetes_service_account.generated_sa.name
+  value       = kubernetes_service_account.generated_sa.metadata[0]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -13,3 +13,7 @@ variable "role_policy_arns" {
   description = "List of ARNs of IAM policies to attach to IAM role"
   type        = list(string)
 }
+variable "service_account" {
+  description = "service accounts"
+  type        = string
+}


### PR DESCRIPTION
Why:
Errors received when trying to do "terraform plan" when using the module - the changes seem to resolve the errors received?
```
Error: Unsupported attribute

  on .terraform/modules/irsa/main.tf line 28, in resource "kubernetes_service_account" "generated_sa":
  28:       "eks.amazonaws.com/role-arn" = module.iam_assumable_role.this_iam_role_arn

This object does not have an attribute named "this_iam_role_arn". 
```
Output "this_iam_role_arn" changed to "iam_role_arn" between version 3.16 and version 4.00

Version 3.16
[Outputs](https://github.com/terraform-aws-modules/terraform-aws-iam/tree/7b9ddc8a2671a4f3458fdcbf2f99ddcafbe860bc/modules/iam-assumable-role-with-oidc#outputs)
Version 4.0 and above
[Outputs](https://github.com/terraform-aws-modules/terraform-aws-iam/tree/ad99ddaa4a3a63352ab5f3d3c731536f56bb2cd2/modules/iam-assumable-role-with-oidc#outputs)

And errors:
```
Error: Unsupported attribute

output "aws_iam_role_name" {
  on .terraform/modules/irsa/outputs.tf line 8, in output "service_account_name":
   8:   value       = kubernetes_service_account.generated_sa.name

This object has no argument, nested block, or exported attribute named "name".
```
```
Error: Invalid operation

  on .terraform/modules/irsa/outputs.tf line 8, in output "service_account_name":
   8:   value       = kubernetes_service_account.generated_sa.metadata.name

Block type "metadata" is represented by a list of objects, so it must be
indexed using a numeric key, like .metadata[0].
```
Think ".metadata[0] should pick up "  name      = local.identifier"?