### PR TITLE
Change documentation of `service_account_name` output variable to downplay it being a "name"

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,6 @@ See [examples](examples/) folder
 | Name | Description |
 |------|-------------|
 | aws\_iam\_role\_name | IAM role name to assume by the SA using annotations |
-| service\_account\_name | Name of the service account created |
+| service\_account\_name | Service account created |
 
 <!--- END_TF_DOCS --->

--- a/outputs.tf
+++ b/outputs.tf
@@ -4,6 +4,7 @@ output "aws_iam_role_name" {
 }
 
 output "service_account_name" {
-  description = "Name of the service account created"
+  # NB: This is not the name of the service account, but the entire object
+  description = "Service account created"
   value       = kubernetes_service_account.generated_sa.metadata[0]
 }


### PR DESCRIPTION
The `service_account_name` is not actually a name, but the entire metadata object. The sample code correctly uses `.name` on this output variable to get its name, however the variable name is misleading.

I really don't think this "fix" is the right route :) but I don't know your processes for this sort of problem.

I figure the best solution is to actually turn this into a name, but there already are a handful of namespaces using this module: a new release with such a breaking change would necessitate removing `.name` from k8s secret definitions when upgrading.